### PR TITLE
Disable login without value for email and password fields

### DIFF
--- a/web/app/controllers/Secure.java
+++ b/web/app/controllers/Secure.java
@@ -17,16 +17,33 @@ public class Secure extends Controller {
         login();
     }
 
-    public static void authenticate(String username, String password){
-        User u = User.loadUser(username);
-        if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
-            session.put("username", username);
-            session.put("password", password);
-            Application.index();
-        }else{
-            flash.put("error", Messages.get("Public.login.error.credentials"));
-            login();
-        }
-
-    }
+   public static void authenticate(String username, String password){
+    	
+    	//Validate entry arguments username & password
+    	boolean Userempty = StringUtils.isEmpty(username);
+    	boolean Passwordempty = StringUtils.isEmpty(password);
+    	
+    	
+    	 if (Userempty != false ){
+    		 flash.put("error", Messages.get("Public.login.error.email.field"));
+             login();
+         }else{	 
+        	 if (Passwordempty != false ){
+        		 flash.put("error", Messages.get("Public.login.error.password.field"));
+                 login();
+        	 }else{
+		    	System.out.println("username is:" + username);
+		    	User u = User.loadUser(username);
+		        if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
+		            session.put("username", username);
+		            session.put("password", password);
+		            Application.index();
+		        }else{
+		            flash.put("error", Messages.get("Public.login.error.credentials"));
+		            login();
+		        }
+		
+		    }
+         }
+   }
 }

--- a/web/conf/messages
+++ b/web/conf/messages
@@ -1,4 +1,4 @@
-##### Login ######
+##### Login #####
 Public.login.title=Login to your account
 Public.login.email=Email
 Public.login.password=Password

--- a/web/conf/messages
+++ b/web/conf/messages
@@ -1,4 +1,4 @@
-##### Login #####
+##### Login ######
 Public.login.title=Login to your account
 Public.login.email=Email
 Public.login.password=Password
@@ -11,6 +11,9 @@ Public.login.forgot.link=here
 Public.login.create.description=Don't have an account yet?
 Public.login.create.link=Create an account
 Public.login.error.credentials=Invalid credentials
+Public.login.error.email.field=Email field is required
+Public.login.error.password.field=Password field is required
+
 
 
 ##### Register #####


### PR DESCRIPTION
The login form allow to login without user and password. It is because the arguments pass as string format will never be Null. 

The authenticate() class try to validate when u (username argument) is different to Null if so, the process continue. As the string is never Null the authentication without user and password is possible.
External note:
An empty Java String is considered as the not null String that contains zero characters, meaning its length is 0

Read more: http://www.java67.com/2014/09/right-way-to-check-if-string-is-empty.html#ixzz5mhNpw7Wp 