### PR TITLE
Invalidar sesión en logout y control session.maxage

### DIFF
--- a/web/app/controllers/Secure.java
+++ b/web/app/controllers/Secure.java
@@ -13,7 +13,7 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.clear();
         login();
     }
 

--- a/web/conf/application.conf
+++ b/web/conf/application.conf
@@ -46,7 +46,7 @@ date.format=yyyy-MM-dd
 # The cookies are not secured by default, only set it to true
 # if you're serving your pages through https.
 # application.session.cookie=PLAY
-# application.session.maxAge=1h
+application.session.maxAge=1h
 # application.session.secure=false
 
 # Session/Cookie sharing between subdomain


### PR DESCRIPTION
En el método **Secure.logout()** se ha controlado que al hacer logout se invalide la sesión (método **session.clear()**), ya que antes sólo se eliminaba la **password** de la sesión, pero no el usuario, a pesar de que lo que se comprobaba para verificar si había sesión ya abierta era el **username,** por eso se accedía a la sesión del usuario anterior. 

`    public static void logout(){
        session.clear();
        login();
    }
`

Además se ha activado en el fichero de configuración **application.conf** la duración máxima de la sesión (en este caso a 1h):

`application.session.maxAge=1h`