### PR TITLE
Corregido almacenamiento de credenciales en claro

### DIFF
--- a/web/app/controllers/PublicContentBase.java
+++ b/web/app/controllers/PublicContentBase.java
@@ -4,6 +4,7 @@ package controllers;
 import helpers.HashUtils;
 import models.User;
 import play.mvc.Controller;
+import models.Constants;
 
 public class PublicContentBase extends Controller {
 
@@ -12,7 +13,7 @@ public class PublicContentBase extends Controller {
     }
 
     public static void processRegister(String username, String password, String passwordCheck, String type){
-        User u = new User(username, HashUtils.getMd5(password), type, -1);
+        User u = new User(username, HashUtils.getMd5(username + Constants.User.SALT + password), type, -1);
         u.save();
         registerComplete();
     }

--- a/web/app/controllers/Secure.java
+++ b/web/app/controllers/Secure.java
@@ -3,6 +3,7 @@ package controllers;
 
 import helpers.HashUtils;
 import models.User;
+import models.Constants;
 import play.i18n.Messages;
 import play.mvc.Controller;
 
@@ -19,7 +20,7 @@ public class Secure extends Controller {
 
     public static void authenticate(String username, String password){
         User u = User.loadUser(username);
-        if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
+        if (u != null && u.getPassword().equals(HashUtils.getMd5(username + Constants.User.SALT + password))){
             session.put("username", username);
             session.put("password", password);
             Application.index();

--- a/web/app/helpers/HashUtils.java
+++ b/web/app/helpers/HashUtils.java
@@ -7,17 +7,18 @@ import java.security.MessageDigest;
 public class HashUtils {
 
     public static String getMd5(String s){
+        String hashtext="";
         try {
             MessageDigest m = MessageDigest.getInstance("MD5");
             m.reset();
             m.update(s.getBytes());
             byte[] digest = m.digest();
             BigInteger bigInt = new BigInteger(1,digest);
-            String hashtext = bigInt.toString(16);
+            hashtext = bigInt.toString(16);
             while(hashtext.length() < 32){
                 hashtext = "0" + hashtext;
             }
         } catch (Exception e) {}
-        return s;
+        return hashtext;
     }
 }

--- a/web/app/models/Constants.java
+++ b/web/app/models/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
 
         public static final String TEACHER = "teacher";
         public static final String STUDENT = "student";
+        public static final String SALT = "M8_SALT_Tarea_Colaborativa";
     }
 
 


### PR DESCRIPTION
Coregido el almacenamiento de credenciales en claro.  Ahora las credenciales se almacenan hasheadas en MD5 y salteadas