### PR TITLE
fix: Controlar el acceso a funcionalidades específicas para el rol de "teacher"

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -2,6 +2,7 @@ package controllers;
 
 import models.Constants;
 import models.User;
+import play.i18n.Messages;
 import play.mvc.*;
 
 import java.util.List;
@@ -43,6 +44,9 @@ public class Application extends Controller {
 
 
     public static void removeStudent(String student) {
+        ensureUserIsLoggedIn();
+        ensureUserIsATeacher();
+
         checkTeacher();
 
         User.remove(student);
@@ -51,14 +55,38 @@ public class Application extends Controller {
 
 
     public static void setMark(String student) {
+        ensureUserIsLoggedIn();
+        ensureUserIsATeacher();
+
         User u = User.loadUser(student);
         render(u);
     }
 
     public static void doSetMark(String student, Integer mark) {
+        ensureUserIsLoggedIn();
+        ensureUserIsATeacher();
+
         User u = User.loadUser(student);
         u.setMark(mark);
         u.save();
         index();
+    }
+
+    private static void ensureUserIsLoggedIn() {
+        if (session.contains("username")) {
+            return;
+        }
+
+        flash.put("error", Messages.get("Public.authentication.user_not_logged_in"));
+        Secure.login();
+    }
+
+    private static void ensureUserIsATeacher() {
+        if (session.contains("role") && session.get("role").equals(Constants.User.TEACHER)) {
+            return;
+        }
+
+        flash.put("error", Messages.get("Public.authorization.user_is_not_a_teacher"));
+        Application.index();
     }
 }

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -13,7 +13,7 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.remove("username");
         login();
     }
 
@@ -21,7 +21,7 @@ public class Secure extends Controller {
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
-            session.put("password", password);
+            session.put("role", u.getType());
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/app/views/main2.html
+++ b/app/views/main2.html
@@ -25,6 +25,11 @@
         </div>
 
         <div id="login">
+            #{if flash.error}
+            <p class="error">
+                &{flash.error}
+            </p>
+            #{/if}
             #{doLayout /}
         </div>
     </div>

--- a/conf/messages
+++ b/conf/messages
@@ -24,3 +24,9 @@ Public.register.validation.name=Please enter a display name we can use to addres
 Public.register.validation.password=Please enter a password
 Public.register.validation.passwordConfirmation=Please confirm your password
 Public.register.validation.existingAccount=This account is already registered. Forgot your password?
+
+##### Authentication #####
+Public.authentication.user_not_logged_in=Please, log in
+
+##### Authorization #####
+Public.authorization.user_is_not_a_teacher=You are not a teacher


### PR DESCRIPTION
En esta pull request me he centrado en la siguiente vulnerabilidad que ha reportado Sergio Noel Moreno Pérez:

![image](https://user-images.githubusercontent.com/10118710/167460191-896edde3-7be2-44f4-b5cf-49de7ebcb581.png)

Lo que he hecho ha sido implementar autentificación y autorización a las funcionalidades de modificar la nota y borrar un estudiante solo para el rol de profesor.

Para ello, se han creado dos métodos privados dentro de la clase `Application`:
* `ensureUserIsLoggedIn`: Este método se utiliza para la autenticación, asegurando que el usuario está logueado.
* `ensureUserIsATeacher`: Este método se utiliza para la autorización, asegurando que el usuario logueado tiene el rol de profesor.

Estos dos métodos se llaman en:
* `setMark`: Es el método que se llama al cargar el formulario de modificar la nota.
* `doSetMark`: Es el método que se llama cuando enviamos el formulario de modificar la nota al servidor.
* `removeStudent`: Es el método que se llama cuando se elimina un estudiante.

Por último, he modificado los datos que se guardan/borran de la sesión para determinar si el usuario está logueado o no.