### PR TITLE
Fix: Avoid register process from overwriting users

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -12,12 +12,21 @@ public class PublicContentBase extends Controller {
     }
 
     public static void processRegister(String username, String password, String passwordCheck, String type){
-        User u = new User(username, HashUtils.getMd5(password), type, -1);
-        u.save();
+        User safeUser = User.loadUser(username);
+        if (safeUser != null){
+            registerError();
+            return;
+        }
+        User newUser = new User(username, HashUtils.getMd5(password), type, -1);
+        newUser.save();
         registerComplete();
     }
 
     public static void registerComplete(){
+        render();
+    }
+
+    public static void registerError(){
         render();
     }
 }

--- a/app/views/PublicContentBase/registerError.html
+++ b/app/views/PublicContentBase/registerError.html
@@ -1,0 +1,9 @@
+#{extends 'main.html' /}
+#{set title:'Register Complete' /}
+
+
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <p>Error, username taken. <a href="@{PublicContentBase.register()}">Try again here</a> to start.</p>
+    </div>
+</div>

--- a/users/hola
+++ b/users/hola
@@ -1,0 +1,1 @@
+{"username":"hola","password":"hola","type":"student","mark":10}

--- a/users/test
+++ b/users/test
@@ -1,0 +1,1 @@
+{"username":"test","password":"test","type":"teacher","mark":-1}


### PR DESCRIPTION
Right now the application is not checking if a user exists before registering a new one. This causes that if a user tries to register with a username already taken the previous user is overwritten.

This patch solve this problem adding a little check before creating a new user. This check will send the user to an error page and cancel the user creation if the username is already taken.

------------------------

Ahora mismo la aplicación no está comprobando si existe un usuario antes de registrar uno nuevo. Esto provoca que si un usuario intenta registrarse con un nombre de usuario cogido, el usuario anterior es sobrescrito.

Este parche resuelve el problema agregando una pequeña verificación antes de crear un nuevo usuario. Esta verificación enviará al usuario a una página de error y cancelará la creación del usuario si el nombre de usuario ya está en uso.

Ángel Heredia