### PR TITLE
Logout - Remove username data from cookie

### DIFF
--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -14,6 +14,7 @@ public class Secure extends Controller {
 
     public static void logout(){
         session.remove("password");
+        session.remove("username");
         login();
     }
 


### PR DESCRIPTION
Now the application keeps sensitive data about user session even after logout. This means an attacker could lead into username enumeration through javascript code runing in username´s pc. As the username data is not used by the application after the logout, it is not a problem to remove it directly from cookie.

This change removes username data save in cookie after logout.