### PR TITLE
Fixed null user type on backend and frontend

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -12,6 +12,8 @@ public class PublicContentBase extends Controller {
     }
 
     public static void processRegister(String username, String password, String passwordCheck, String type){
+        if (type == null)
+            type = "student";
         User u = new User(username, HashUtils.getMd5(password), type, -1);
         u.save();
         registerComplete();

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -22,7 +22,7 @@ public class User {
         this.username = json.has(Constants.User.FIELD_USERNAME) ? json.get(Constants.User.FIELD_USERNAME).getAsString() : "";
         this.password = json.has(Constants.User.FIELD_PASSWORD) ? json.get(Constants.User.FIELD_PASSWORD).getAsString() : "";
         this.mark = json.has(Constants.User.FIELD_MARK) ? json.get(Constants.User.FIELD_MARK).getAsInt() : 0;
-        this.type = json.has(Constants.User.FIELD_TYPE) ? json.get(Constants.User.FIELD_TYPE).getAsString() : "teacher";
+        this.type = json.has(Constants.User.FIELD_TYPE) ? json.get(Constants.User.FIELD_TYPE).getAsString() : "student";
     }
 
     public User(String username, String password, String type, Integer mark) {

--- a/app/views/PublicContentBase/register.html
+++ b/app/views/PublicContentBase/register.html
@@ -74,7 +74,7 @@
 
         <div>
             <input type="radio" name="type" value="teacher">Teacher
-            <input type="radio" name="type" value="student">Student
+            <input type="radio" name="type" value="student" checked>Student
         </div>
 
 


### PR DESCRIPTION
This pull request fixes the error that occurs when the user registers without selecting the user type "teacher" or "student".

- [x] Default "student" selection on frontend
- [x] Default "student" type set on backend if none selected
- [x] Default "student" type used in backend if none saved to give less privileges, previously "teacher" was used