### PR TITLE
Add username no repeated

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -4,6 +4,7 @@ package controllers;
 import helpers.HashUtils;
 import models.User;
 import play.mvc.Controller;
+import play.i18n.Messages;
 
 public class PublicContentBase extends Controller {
 
@@ -12,9 +13,14 @@ public class PublicContentBase extends Controller {
     }
 
     public static void processRegister(String username, String password, String passwordCheck, String type){
-        User u = new User(username, HashUtils.getMd5(password), type, -1);
-        u.save();
-        registerComplete();
+        if (User.loadUser(username) == null){
+            User u = new User(username, HashUtils.getMd5(password), type, -1);
+            u.save();
+            registerComplete();
+        }else{
+            flash.put("repeated", Messages.get("Public.login.userRepeated"));
+            register();
+        }
     }
 
     public static void registerComplete(){

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -76,10 +76,6 @@ public class User {
         json.addProperty(Constants.User.FIELD_MARK, mark);
 
         File file = getFile();
-        if (file.exists()){
-            file.delete();
-        }
-
         try {
             file.createNewFile();
             FileOutputStream out = new FileOutputStream(file);

--- a/app/views/PublicContentBase/register.html
+++ b/app/views/PublicContentBase/register.html
@@ -46,6 +46,10 @@
 #{form @processRegister(), id:'form', name:'reg-form'}
 <h2 class="text-left">&{'Public.register.title'}</h2>
 
+#{if flash.repeated}
+    <script> alert("&{flash.repeated}")</script>
+#{/if}
+
 #{ifErrors}
 <div id="register_error" class="error">${errors[0]}</div>
 #{/ifErrors}

--- a/conf/messages
+++ b/conf/messages
@@ -11,6 +11,7 @@ Public.login.forgot.link=here
 Public.login.create.description=Don't have an account yet?
 Public.login.create.link=Create an account
 Public.login.error.credentials=Invalid credentials
+Public.login.userRepeated=User already exists, enter another user
 
 
 ##### Register #####


### PR DESCRIPTION
Solución para la validación de usuarios, no permite crear nuevos usuarios con un username ya existente. Solución realizada en frontend con una ventana emergente cuando se quiere crear un usuario nuevo con un username ya existente y así evitar una suplantación de identidad, y en backend comprobando si el usuario que se quiere crear ya esta en users, para controlar los usuarios ya creados.
Ignacio Rueda Rodríguez