### PR TITLE
Correción vulnerabilidad del encabezado X-Content-Type-Options

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -238,3 +238,8 @@ mail.smtp=mock
 %test.jpa.ddl=create
 %test.mail.smtp=mock
 
+# Set Content Security Policy to allow only resources from the same origin and prevent the execution of insecure resources
+play.filters.headers.contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';"
+
+# Set the X-Content-Type-Options header to 'nosniff' to prevent MIME-sniffing
+play.filters.headers.xContentTypeOptions = "nosniff"


### PR DESCRIPTION
Modificación del encabezado X-Content-Type-Options con el valor 'nosniff' para prevenir ataques de MIME-sniffing y garantizar la correcta interpretación del tipo de contenido por parte del navegador.

Y añadida política de seguridad de contenido que permite solo recursos del mismo origen, para evitar la ejecución de recursos inseguros (evitar ataques xss entre otros).