### PR TITLE
Modificar cabeceras http (vulnerabilidad nosniff)

### DIFF
--- a/app/controllers/Api.java
+++ b/app/controllers/Api.java
@@ -8,6 +8,8 @@ import play.mvc.Controller;
 public class Api extends Controller {
 
     public static void removeAllUsers(){
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");
         User.removeAll();
         renderJSON(new JsonObject());
     }

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -29,6 +29,9 @@ public class Application extends Controller {
     }
 
     public static void index() {
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");
+
         checkUser();
 
         User u = (User) renderArgs.get("user");

--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -8,6 +8,7 @@ import play.mvc.Controller;
 public class PublicContentBase extends Controller {
 
     public static void register(){
+        response.setHeader("X-Content-Type-Options", "nosniff");
         render();
     }
 
@@ -18,6 +19,7 @@ public class PublicContentBase extends Controller {
     }
 
     public static void registerComplete(){
+        response.setHeader("X-Content-Type-Options", "nosniff");
         render();
     }
 }

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -9,15 +9,22 @@ import play.mvc.Controller;
 public class Secure extends Controller {
 
     public static void login(){
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");
         render();
     }
 
     public static void logout(){
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");
         session.remove("password");
         login();
     }
 
     public static void authenticate(String username, String password){
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");
+
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);


### PR DESCRIPTION
He añadido las linea:

- response.setHeader("X-Content-Type-Options", "nosniff");

Para solucionar la vulnerabilidad comentada por el compañero Valentín, respecto a la cabecera "X-Content-Type-Options".
También he añadido una política de seguridad para evitar los ataques XSS.

- response.setHeader("Content-Security-Policy", "default-src 'self'; 
script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; frame-src 'self'; connect-src 'self'; object-src 'none'; media-src 'self';");

Las he añadido en los módulos de los controladores, y en el caso de PublicContentBase sólo he establecido la cabecera "nosniff" para que  la creación de nuevas cuentas funcionase correctamente.

He borrado el anterior pull-request ya que no había entendido correctamente la práctica y no estaba solucionando el error en la versión del framework en el que funciona ésta aplicación (v1).

Saludos.