### PR TITLE
 ED12_MCS_M8AC1 | Eliminación de usuarios vía API

### DIFF
--- a/app/controllers/Api.java
+++ b/app/controllers/Api.java
@@ -1,14 +1,24 @@
 package controllers;
 
-
 import com.google.gson.JsonObject;
+
+import helpers.ApiAuth;
 import models.User;
 import play.mvc.Controller;
 
 public class Api extends Controller {
 
     public static void removeAllUsers(){
-        User.removeAll();
-        renderJSON(new JsonObject());
+        JsonObject o = new JsonObject();
+        String result = ApiAuth.checkCookie();
+        if (result != "" || result == null) {
+            o.addProperty("message", "Not authorized : " + result);
+        }
+        else {
+            User.removeAll();
+            o.addProperty("message", "Users removed succesfully");
+        }
+
+        renderJSON( o );
     }
 }

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -23,7 +23,7 @@ public class Secure extends Controller {
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
             session.put("password", password);
-            ApiAuth.createCookie( u.getType() );
+            ApiAuth.createCookie();
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -1,6 +1,7 @@
 package controllers;
 
 
+import helpers.ApiAuth;
 import helpers.HashUtils;
 import models.User;
 import play.i18n.Messages;
@@ -13,7 +14,7 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.clear();
         login();
     }
 
@@ -22,6 +23,7 @@ public class Secure extends Controller {
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
             session.put("password", password);
+            ApiAuth.createCookie( u.getType() );
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/app/helpers/ApiAuth.java
+++ b/app/helpers/ApiAuth.java
@@ -1,0 +1,134 @@
+package helpers;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Base64.Encoder;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import models.User;
+import models.Constants;
+import play.mvc.Http;
+import play.mvc.Scope.Session;
+import play.Play;
+
+public class ApiAuth {
+    
+    static String key = Play.configuration.get("tokenKey").toString();
+    static String hmacAlg = Play.configuration.get("tokenAlg").toString();
+    static Integer daystoExpire = Integer.parseInt( Play.configuration.get("tokenTime").toString() );
+    
+    private static String createSign(String algorithm, String data, String key) throws NoSuchAlgorithmException, InvalidKeyException {
+        
+        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), algorithm);
+        Mac mac = Mac.getInstance(algorithm);
+        mac.init(secretKeySpec);
+        Encoder e = Base64.getUrlEncoder().withoutPadding();
+        
+        return e.encodeToString( mac.doFinal( data.getBytes() ) );
+    }
+    
+    
+    private static String buildData() {  // Create a Base64encoded string from Header and Payload parts
+        
+        Session session = Session.current(); /// Get current session
+        Encoder enc = Base64.getUrlEncoder().withoutPadding(); // Coder without Base64 padding '='
+        Date iat = new Date();
+        JsonObject header = new JsonObject(); // Building header
+            header.addProperty("typ", "JWT");
+            header.addProperty("alg", "HS256");
+        JsonObject payload = new JsonObject(); // Building Payload
+            payload.addProperty("username", session.get("username"));
+            payload.addProperty("iat", iat.getTime() ); // Creation time. Used to verify if token is expired against current time.
+
+        return enc.encodeToString( header.toString().getBytes() ) + "." + enc.encodeToString( payload.toString().getBytes() );
+    }
+
+    private static Boolean expiredToken( String payload ) { // Check if a valid token is expired
+        
+        try {
+            String payloadDecoded = new String( Base64.getUrlDecoder().decode(payload) ); // Decode payload part to extract iatString
+            JsonObject payloadObj = new JsonParser().parse( payloadDecoded ).getAsJsonObject();
+            Long iat = Long.parseLong( payloadObj.get("iat").getAsString() );
+            Long maxTime = iat + (daystoExpire * 24 * 60 * 60 * 1000); 
+            Long now = (new Date()).getTime();
+            
+            return maxTime < now;
+        } catch (Exception e) {
+            
+            return false;
+        }
+    }
+
+    private static Boolean validToken( String[] splitToken ) { // Check if a token is right signed
+        
+        String originToken = String.join(".",splitToken);
+        String headerAndPayload = splitToken[0]+"."+splitToken[1];
+
+        try {
+            String sign = createSign(hmacAlg, headerAndPayload, key); // Create a sign from parts received
+            String finalToken = headerAndPayload+"."+sign;
+            return originToken == finalToken;
+        } catch (Exception e) {
+            System.err.println( e.getMessage() );
+            return false;
+        }   
+    }
+
+    private static String validateJWT( Http.Cookie cookie ) { // return an empty String if everything goes right
+        
+        try {
+            String[] splitToken = cookie.value.split("\\."); // Extract Header and Payload                    
+            if (validToken(splitToken)) 
+                return "Invalid token"; 
+            if (expiredToken(splitToken[1])) 
+                return "Token expired"; 
+        } catch (Exception e) {
+            return "Error validating token : "+e.getMessage();
+        }
+        
+        return "";
+    }
+
+    private static String generateJWT( String type ) { // generate pieces for final JWT
+        
+        String jwt = "";
+        
+        // Only tokens for allowed profile (teacher)
+        User u = User.loadUser( Session.current().get("username") );
+        if (u == null || !u.getType().equals( Constants.User.TEACHER ) )
+            return "";
+        
+        String data = buildData(); // Create Header & Payload with current session data
+        try {
+            String sign = createSign(hmacAlg, data, key);
+            jwt = data+"."+sign;
+        } catch (Exception e) {
+            System.err.println( e.getMessage() );
+        }   
+        return jwt;     
+    }
+
+    public static void createCookie( String type ) {
+        
+        Http.Response response = Http.Response.current(); // Access to Response flow
+        String token = generateJWT( type );
+        if (token != "") 
+            response.setCookie("apiCookie", token, String.format("%sd", daystoExpire.toString()) ); // Rewrite Cookie if exists
+        else
+            response.removeCookie("apiCookie"); // Privacy - Remove posible existing cookie if any error or logged profile is not allowed
+    }
+
+
+    public static String checkCookie() {
+        
+        Http.Request request  = Http.Request.current(); // Access to Request flow
+        Http.Cookie sessionCookie = request.cookies.get("apiCookie");
+        return validateJWT(sessionCookie);
+    }
+
+}

--- a/app/helpers/ApiAuth.java
+++ b/app/helpers/ApiAuth.java
@@ -94,7 +94,7 @@ public class ApiAuth {
         return "";
     }
 
-    private static String generateJWT( String type ) { // generate pieces for final JWT
+    private static String generateJWT() { // generate pieces for final JWT
         
         String jwt = "";
         
@@ -113,10 +113,10 @@ public class ApiAuth {
         return jwt;     
     }
 
-    public static void createCookie( String type ) {
+    public static void createCookie() {
         
         Http.Response response = Http.Response.current(); // Access to Response flow
-        String token = generateJWT( type );
+        String token = generateJWT();
         if (token != "") 
             response.setCookie("apiCookie", token, String.format("%sd", daystoExpire.toString()) ); // Rewrite Cookie if exists
         else

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -84,6 +84,7 @@ public class User {
             file.createNewFile();
             FileOutputStream out = new FileOutputStream(file);
             out.write(json.toString().getBytes());
+            out.close();
         } catch (IOException e) {
             Logger.error("Error saving user: " + username);
             Logger.error(e.getMessage());

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,6 +15,11 @@ application.mode=dev
 # If you deploy your application to several instances be sure to use the same key !
 application.secret=IvqEohdGi2SGsO5Y4UEhWQrVIir779hGzYklvjSHY6pQD0w3Tn9zMollkBqGN0lY
 
+# API Token secret
+tokenKey=My4wesomeP4ssw0rD
+tokenAlg=HmacSHA256
+tokenTime=1
+
 # i18n
 # ~~~~~
 # Define locales used by your application.


### PR DESCRIPTION
### **Correcciones para vulnerabilidades detectadas en acceso a la API**

### Problemas encontrados
Las peticiones GET a la API mediante la ruta `/api/QPEGLSDSfasdflqed` no están autenticadas, por lo que se permitiría la ejecución a cualquiera conocedor de esta URL, con la consecuente pérdida de los TODOS ficheros de usuarios ubicados en la ruta `/users`

### Solución aportada

- Para limitar el uso de la API se ha pensado en un sistema de tokens como es **Json Web Tokens** (JWT). Usaremos librerías criptográficas de Java para nuestras funciones hmac. A tal fin, se ha implementado un "helper" `helper/ApiAuth.java` que se encarga de crear y verificar, de forma básica, tokens de acceso.
- Disponemos de dos métodos públicos para crear y verificar:

> `createCookie()` : Cada vez que el usuario se loga satisfactoriamente en la aplicación se genera un token firmado (sobreescribiendo a cualquiera que existiera anteriormente) que indica, tanto el nombre del usuario logado, como la marca de tiempo de cuándo se creó. El payload del JWT tiene la siguiente estructura:` { username: x, iat: x}`. La propiedad `iat` es donde se almacenará la marca de tiempo que será comprobada en el siguiente método, descrito más abajo, para comprobar si ha expirado. Este token se guardará en el valor de una cookie llamada "apiCookie".

> `checkCookie()` : Cuando se hace una llamada vía API directa, se rescata la cookie previamente creada, se lee el valor que contiene el token y posteriormente se verifica (validez de firma y expiración). Si es satisfactoria se procede a ejecutar el método `removeAll()` del objeto `User`.

### Notas

- El archivo de configuración `conf/application.conf` de nuestra app de Play se ha modificado también para incluir parámetros privados que condicionarán la creación de los tokens.
- Todo se ha implementado con librerías nativas, sin dependencias fuera de Play.