### PR TITLE
Gestión de cookies (flag “secure)

### DIFF
--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -13,7 +13,7 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("username");
+        session.remove("password");
         login();
     }
 
@@ -21,6 +21,7 @@ public class Secure extends Controller {
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
+            session.put("password", password);
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -13,7 +13,7 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.remove("username");
         login();
     }
 
@@ -21,7 +21,6 @@ public class Secure extends Controller {
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
-            session.put("password", password);
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,9 +45,10 @@ http.port=9090
 # By default, session will be written to the transient PLAY_SESSION cookie.
 # The cookies are not secured by default, only set it to true
 # if you're serving your pages through https.
-# application.session.cookie=PLAY
-# application.session.maxAge=1h
-# application.session.secure=false
+application.session.cookie=PLAY
+application.session.maxAge=1h
+application.session.secure=true
+application.session.sendOnlyIfChanged=true
 
 # Session/Cookie sharing between subdomain
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Gestión de cookies
Se ha añadido que las cookies sean marcadas con el nombre de PLAY, como seguras, con una duración de 1h. ünicamente se enviarán cuando se detecte que han cambiado, esto reduce el tráfico entre el servidor y el cliente. Para que este cambio funcione es necesario que el sistema esté tembién confiugurado para funcionar con el protocolo https. Solución propuesta en el pull-request de https://github.com/jaesga/master-ciberseguridad-web-colaborativa/pull/39