### PR TITLE
Eliminada información sensible en vista de errores 404

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,7 +6,7 @@ application.name=master-ciberseguridad
 # ~~~~~
 # Set to dev to enable instant reloading and other development help.
 # Otherwise set to prod.
-application.mode=dev
+application.mode=prod
 %prod.application.mode=prod
 
 # Secret key


### PR DESCRIPTION
Se ha realizado una modificación en el archivo de configuración debido a que la version desplegada esta usando el modo DEV. Con esta corrección ya no se deberían de poder ver información respecto a las rutas exponiendo información sensible.
En cuanto a la posibilidad de evitar enumeraciones de rutas, he revisado la configuración de rutas, debido a que estamos usando una version antigua del framework Play! no se puede hacer un customErrorHandle de las rutas( cosa que si se puede hacer en versiones mas actuales [Mas información](https://www.playframework.com/documentation/2.6.x/ScalaErrorHandling) ), por ello se mantiene la vista por defecto del error 404, ya que otras opciones como una redirección a posterior de acceder a esta vista podrían ser tambien utilizado como patron en ataques de diccionarios de enumeración de rutas
